### PR TITLE
Improve image view layout and fix navigation consistency

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -125,6 +125,64 @@ body {
   border-bottom: 1px solid var(--border-medium);
 }
 
+/* Compact View Header for Image View */
+.view-header-compact {
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-light);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-2) var(--space-4);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.view-header-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.view-filename {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--gray-800);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 var(--space-2);
+}
+
+.view-user-info {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+  white-space: nowrap;
+}
+
+/* Responsive design for compact header */
+@media (max-width: 768px) {
+  .view-header-compact {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .view-header-content {
+    grid-template-columns: auto 1fr;
+    gap: var(--space-2);
+  }
+
+  .view-filename {
+    font-size: 0.8125rem;
+    text-align: left;
+  }
+
+  .view-user-info {
+    display: none;
+  }
+}
+
 .header-content {
   max-width: 1200px;
   margin: 0 auto;
@@ -1488,8 +1546,8 @@ ul li:hover {
 
 .compact-classifications-header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
   gap: var(--space-3);
 }
 
@@ -1497,7 +1555,7 @@ ul li:hover {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
-  flex: 1;
+  justify-content: center;
 }
 
 .compact-class-btn {
@@ -1681,17 +1739,17 @@ ul li:hover {
 /* Responsive adjustments for compact classifications */
 @media (max-width: 768px) {
   .compact-classifications-header {
-    flex-direction: column;
-    align-items: stretch;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
   }
-  
+
   .classifications-buttons {
     justify-content: center;
   }
-  
+
   .compact-help-controls {
-    align-self: center;
-    margin-top: var(--space-2);
+    order: 2;
   }
   
   .help-sections {
@@ -1905,13 +1963,13 @@ ul li:hover {
 #image-display {
   display: flex;
   justify-content: center;
-  align-items: center;
-  min-height: 400px;
+  align-items: flex-start;
+  height: calc(100vh - 50px);
   background: var(--bg-primary);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-lg);
-  margin: var(--space-6) 0;
-  padding: var(--space-4);
+  margin: 0;
+  padding: var(--space-1);
   box-shadow: var(--shadow-md);
   overflow: auto;
   position: relative;
@@ -1927,7 +1985,8 @@ ul li:hover {
 
 #image-display .view-image {
   max-width: 100%;
-  max-height: 80vh;
+  max-height: calc(100vh - 55px);
+  width: auto;
   height: auto;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
@@ -1960,24 +2019,26 @@ ul li:hover {
 .image-navigation {
   display: flex;
   justify-content: center;
-  gap: var(--space-4);
-  margin: var(--space-6) 0;
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
 }
 
 .navigation-btn {
-  min-width: 120px;
+  min-width: 80px;
+  padding: var(--space-2) var(--space-3);
+  font-size: 0.875rem;
 }
 
 /* Responsive adjustments for image display */
 @media (max-width: 768px) {
   #image-display {
-    min-height: 300px;
-    margin: var(--space-4) 0;
-    padding: var(--space-3);
+    height: calc(100vh - 40px);
+    margin: 0;
+    padding: var(--space-1);
   }
-  
+
   #image-display .view-image {
-    max-height: 60vh;
+    max-height: calc(100vh - 45px);
   }
   
   .image-controls {
@@ -1991,7 +2052,9 @@ ul li:hover {
   }
   
   .navigation-btn {
-    min-width: 100px;
+    min-width: 70px;
+    padding: var(--space-2);
+    font-size: 0.8125rem;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -72,6 +72,12 @@
   --transition-fast: 150ms ease-in-out;
   --transition-normal: 250ms ease-in-out;
   --transition-slow: 350ms ease-in-out;
+
+  /* Image View Layout */
+  --view-header-height: 50px;
+  --view-image-reserve: 55px;
+  --view-header-height-mobile: 40px;
+  --view-image-reserve-mobile: 45px;
 }
 
 /* Global Styles */
@@ -1964,7 +1970,7 @@ ul li:hover {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  height: calc(100vh - 50px);
+  height: calc(100vh - var(--view-header-height));
   background: var(--bg-primary);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-lg);
@@ -1985,7 +1991,7 @@ ul li:hover {
 
 #image-display .view-image {
   max-width: 100%;
-  max-height: calc(100vh - 55px);
+  max-height: calc(100vh - var(--view-image-reserve));
   width: auto;
   height: auto;
   border-radius: var(--radius-md);
@@ -2032,13 +2038,13 @@ ul li:hover {
 /* Responsive adjustments for image display */
 @media (max-width: 768px) {
   #image-display {
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--view-header-height-mobile));
     margin: 0;
     padding: var(--space-1);
   }
 
   #image-display .view-image {
-    max-height: calc(100vh - 45px);
+    max-height: calc(100vh - var(--view-image-reserve-mobile));
   }
   
   .image-controls {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1970,6 +1970,8 @@ ul li:hover {
   display: flex;
   justify-content: center;
   align-items: flex-start;
+  /* The height calculation below depends on --view-header-height.
+     If you change the header height, update --view-header-height in :root accordingly. */
   height: calc(100vh - var(--view-header-height));
   background: var(--bg-primary);
   border: 1px solid var(--border-light);

--- a/frontend/src/ImageView.js
+++ b/frontend/src/ImageView.js
@@ -89,7 +89,7 @@ function ImageView() {
       // Sort images by date (newest first) to match the gallery default sorting
       // Use spread operator to avoid mutating the original array
       const sortedImages = [...images].sort((a, b) => {
-        return new Date(b.created_at || 0) - new Date(a.created_at || 0);
+        return new Date(b.created_at || '1970-01-01') - new Date(a.created_at || '1970-01-01');
       });
 
       setProjectImages(sortedImages);

--- a/frontend/src/ImageView.js
+++ b/frontend/src/ImageView.js
@@ -86,10 +86,15 @@ function ImageView() {
         throw new Error('Invalid server response: expected an array of images');
       }
       
-      setProjectImages(images);
-      
-      // Find the index of the current image
-      const index = images.findIndex(img => img.id === imageId);
+      // Sort images by date (newest first) to match the gallery default sorting
+      const sortedImages = images.sort((a, b) => {
+        return new Date(b.created_at || 0) - new Date(a.created_at || 0);
+      });
+
+      setProjectImages(sortedImages);
+
+      // Find the index of the current image in the sorted array
+      const index = sortedImages.findIndex(img => img.id === imageId);
       setCurrentImageIndex(index);
       
     } catch (error) {
@@ -195,25 +200,23 @@ function ImageView() {
   }, [currentImageIndex, projectImages.length, navigateToNextImage, navigateToPreviousImage]);
 
   return (
-    <div className="App" style={{ maxWidth: '100%', padding: '10px' }}>
-      <header className="App-header">
-        <div id="view-header">
-          <button 
-            className="btn btn-secondary" 
+    <div className="App" style={{ maxWidth: '100%', padding: '0' }}>
+      <header className="view-header-compact">
+        <div className="view-header-content">
+          <button
+            className="btn btn-secondary btn-small"
             onClick={() => navigate(`/project/${projectId}`)}
           >
-            &lt; Back to Project
+            ← Back
           </button>
-          <h1>{image ? image.filename : 'Loading image...'}</h1>
+          <span className="view-filename">{image ? image.filename : 'Loading...'}</span>
           {currentUser && (
-            <div className="user-info">
-              <span>Logged in as: {currentUser.email}</span>
-            </div>
+            <span className="view-user-info">{currentUser.email}</span>
           )}
         </div>
       </header>
 
-      <div className="container" style={{ maxWidth: '100%' }}>
+      <div className="container" style={{ maxWidth: '100%', padding: 'var(--space-4)' }}>
         {error && (
           <div className="alert alert-error">
             {error}
@@ -227,39 +230,26 @@ function ImageView() {
         )}
         
         <div className="image-view-container">
-          <div className="image-navigation">
-            <button 
-              className="btn btn-secondary navigation-btn"
-              onClick={navigateToPreviousImage}
-              disabled={currentImageIndex <= 0}
-            >
-              &lt; Previous
-            </button>
-            <button 
-              className="btn btn-secondary navigation-btn"
-              onClick={navigateToNextImage}
-              disabled={currentImageIndex >= projectImages.length - 1 || currentImageIndex === -1}
-            >
-              Next &gt;
-            </button>
-          </div>
-          
           {/* Compact classification buttons above image */}
-          <CompactImageClassifications 
-            imageId={imageId} 
-            classes={classes} 
-            loading={loading} 
-            setLoading={setLoading} 
-            setError={setError} 
+          <CompactImageClassifications
+            imageId={imageId}
+            classes={classes}
+            loading={loading}
+            setLoading={setLoading}
+            setError={setError}
           />
-          
-          <ImageDisplay 
-            imageId={imageId} 
-            image={image} 
+
+          <ImageDisplay
+            imageId={imageId}
+            image={image}
             isTransitioning={isTransitioning}
             projectId={projectId}
             setImage={setImage}
             refreshProjectImages={loadProjectImages}
+            navigateToPreviousImage={navigateToPreviousImage}
+            navigateToNextImage={navigateToNextImage}
+            currentImageIndex={currentImageIndex}
+            projectImages={projectImages}
           />
           
           <ImageComments 

--- a/frontend/src/ImageView.js
+++ b/frontend/src/ImageView.js
@@ -87,7 +87,8 @@ function ImageView() {
       }
       
       // Sort images by date (newest first) to match the gallery default sorting
-      const sortedImages = images.sort((a, b) => {
+      // Use spread operator to avoid mutating the original array
+      const sortedImages = [...images].sort((a, b) => {
         return new Date(b.created_at || 0) - new Date(a.created_at || 0);
       });
 

--- a/frontend/src/components/CompactImageClassifications.js
+++ b/frontend/src/components/CompactImageClassifications.js
@@ -10,7 +10,10 @@ function CompactImageClassifications({ imageId, classes, loading, setLoading, se
     const hotkeyMap = new Map();
     const priorityKeys = ['a', 's', 'd', 'f', 'q', 'w', 'e', 'r']; // Home row + top row
     const allKeys = 'abcdefghijklmnopqrstuvwxyz1234567890'.split('');
-    
+
+    // Reserve 'h' for help functionality
+    usedKeys.add('h');
+
     // First pass: try first letter of class name
     classList.forEach(cls => {
       const firstLetter = cls.name.toLowerCase().charAt(0);

--- a/frontend/src/components/ImageDisplay.js
+++ b/frontend/src/components/ImageDisplay.js
@@ -3,7 +3,18 @@ import React, { useState, useEffect } from 'react';
 // Deleted image placeholder SVG for larger display
 const DELETED_IMAGE_DISPLAY_SVG = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAwIiBoZWlnaHQ9IjYwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iODAwIiBoZWlnaHQ9IjYwMCIgZmlsbD0iI2ZiZjVmNSIgc3Ryb2tlPSIjZjU5ZTBiIiBzdHJva2Utd2lkdGg9IjQiIHN0cm9rZS1kYXNoYXJyYXk9IjE1LDgiLz48dGV4dCB4PSI1MCUiIHk9IjM1JSIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM2IiBmb250LXdlaWdodD0iNjAwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSIgZmlsbD0iI2M0MzAyYiI+SW1hZ2UgRGVsZXRlZDwvdGV4dD48dGV4dCB4PSI1MCUiIHk9IjUwJSIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjY0IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSIgZmlsbD0iI2Y1OWUwYiI+8J+XkeKcgO+4jzwvdGV4dD48dGV4dCB4PSI1MCUiIHk9IjY1JSIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjE4IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSIgZmlsbD0iIzk3OWNhMSI+VGhpcyBpbWFnZSBoYXMgYmVlbiBkZWxldGVkPC90ZXh0Pjx0ZXh0IHg9IjUwJSIgeT0iNzAlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIiBmaWxsPSIjOTc5Y2ExIj5DaGVjayB0aGUgZGVsZXRpb24gY29udHJvbHMgYmVsb3cgZm9yIG1vcmUgaW5mbzwvdGV4dD48L3N2Zz4=';
 
-function ImageDisplay({ imageId, image, isTransitioning, projectId, setImage, refreshProjectImages }) {
+function ImageDisplay({
+  imageId,
+  image,
+  isTransitioning,
+  projectId,
+  setImage,
+  refreshProjectImages,
+  navigateToPreviousImage,
+  navigateToNextImage,
+  currentImageIndex,
+  projectImages
+}) {
   const [zoomLevel, setZoomLevel] = useState(1);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [reason, setReason] = useState("");
@@ -226,32 +237,55 @@ function ImageDisplay({ imageId, image, isTransitioning, projectId, setImage, re
       </div>
       
       <div className="image-controls">
-        <button 
+        {/* Navigation buttons */}
+        {navigateToPreviousImage && (
+          <button
+            className="btn btn-secondary btn-small control-btn"
+            onClick={navigateToPreviousImage}
+            disabled={currentImageIndex <= 0}
+          >
+            ← Prev
+          </button>
+        )}
+        {navigateToNextImage && (
+          <button
+            className="btn btn-secondary btn-small control-btn"
+            onClick={navigateToNextImage}
+            disabled={currentImageIndex >= (projectImages?.length || 0) - 1 || currentImageIndex === -1}
+          >
+            Next →
+          </button>
+        )}
+
+        {/* Zoom controls */}
+        <button
           className="btn btn-secondary control-btn"
           onClick={handleZoomIn}
         >
           Zoom In
         </button>
-        <button 
+        <button
           className="btn btn-secondary control-btn"
           onClick={handleZoomOut}
         >
           Zoom Out
         </button>
-        <button 
+        <button
           className="btn btn-secondary control-btn"
           onClick={handleResetZoom}
         >
           Reset
         </button>
-        <button 
+
+        {/* Other controls */}
+        <button
           className="btn btn-success control-btn"
           onClick={handleDownload}
         >
           Download
         </button>
         {image && !image.deleted_at && (
-          <button 
+          <button
             className="btn btn-danger control-btn"
             onClick={() => setShowDeleteModal(true)}
           >


### PR DESCRIPTION
- Create compact thin header for /view route instead of large header
- Move Previous/Next navigation buttons below image with zoom controls
- Maximize image display size using calc(100vh - 55px) for optimal viewing
- Center classification buttons above image for better layout
- Fix image indexing inconsistency between gallery and image view by sorting both by date
- Reserve 'h' hotkey for help functionality to prevent conflicts
- Optimize layout for maximum image review space with controls below fold

🤖 Generated with [Claude Code](https://claude.ai/code)